### PR TITLE
trpc: add TRPCProvider on root layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import { TRPCProvider } from '@/trpc/client';
 import { ClerkProvider } from '@clerk/nextjs';
 import type { Metadata } from 'next';
 import { Roboto } from 'next/font/google';
@@ -20,7 +21,9 @@ export default function RootLayout({
 	return (
 		<ClerkProvider>
 			<html lang="en">
-				<body className={roboto.className}>{children}</body>
+				<body className={roboto.className}>
+					<TRPCProvider>{children}</TRPCProvider>
+				</body>
 			</html>
 		</ClerkProvider>
 	);


### PR DESCRIPTION
```js
import { TRPCProvider } from '@/trpc/client';
import { ClerkProvider } from '@clerk/nextjs';
import type { Metadata } from 'next';
import { Roboto } from 'next/font/google';
import './globals.css';

const roboto = Roboto({
	subsets: ['latin'],
});

export const metadata: Metadata = {
	title: 'YouTube',
	description: 'Create by: Aldiyes Paskalis Birta',
};

export default function RootLayout({
	children,
}: Readonly<{
	children: React.ReactNode;
}>) {
	return (
		<ClerkProvider>
			<html lang="en">
				<body className={roboto.className}>
					<TRPCProvider>{children}</TRPCProvider> //this one
				</body>
			</html>
		</ClerkProvider>
	);
}

```